### PR TITLE
Removed erroneous aleph/0 call

### DIFF
--- a/prolog/examples/recursion.pl
+++ b/prolog/examples/recursion.pl
@@ -23,7 +23,7 @@
 
 :- determination(mem/2,mem/2).
 :- determination(mem/2,'='/2).
-:-aleph.
+
 :-begin_bg.
 
 :-end_bg.


### PR DESCRIPTION
Second aleph/0 call removed all previous mode and determination declarations. Thus, nothing could be learned by Aleph.